### PR TITLE
Duplicated subpaths in PathEntry fixed

### DIFF
--- a/Signals/Domain/Services/Implementation/SignalsDomainService.cs
+++ b/Signals/Domain/Services/Implementation/SignalsDomainService.cs
@@ -47,6 +47,7 @@ namespace Domain.Services.Implementation
             var subPaths = allSignals
                 .Where(s => s.Path.Length > path.Length + 1)
                 .Select(s => s.Path.GetPrefix(path.Length + 1))
+                .Distinct()
                 .ToArray();
 
             return new PathEntry(directDescendants, subPaths);

--- a/SignalsIntegrationTests/SignalsIntegrationTests/PathStructureTests.cs
+++ b/SignalsIntegrationTests/SignalsIntegrationTests/PathStructureTests.cs
@@ -78,5 +78,20 @@ namespace SignalsIntegrationTests
 
             CollectionAssert.AreEquivalent(new[] { subDirectory }, result.SubPaths.ToArray());
         }
+
+        [TestMethod]
+        public void GivenRootPath_WhenOnePathLevelPresentAndTwoSignalsOnThatLevel_ReturnsOneCommonSubpath()
+        {
+            var directory = Path.Root + "topLevel";
+            var firstTopLevelSignalPath = directory + "topLevelSignal1";
+            var secondTopLevelSignalPath = directory + "topLevelSignal2";
+
+            AddNewIntegerSignal(path: firstTopLevelSignalPath);
+            AddNewIntegerSignal(path: secondTopLevelSignalPath);
+
+            var result = GetPathEntry(Path.Root);
+
+            CollectionAssert.AreEquivalent(new[] { directory }, result.SubPaths.ToArray());
+        }
     }
 }


### PR DESCRIPTION
I have gotten rid of the problem which appeared when there was a few signals with common subpath, PathEntry was returned with a few identical subpaths.
