### PR TITLE
Dbcreate simplified

### DIFF
--- a/Signals/DatabaseMaintenanceTool/App.config
+++ b/Signals/DatabaseMaintenanceTool/App.config
@@ -6,7 +6,8 @@
         </sectionGroup>
     </configSections>
     <connectionStrings>
-        <add name="signals" connectionString="Data Source=(LocalDB)\MSSQLLocalDB" />
+        <add name="master" connectionString="Data Source=(LocalDB)\MSSQLLocalDB" />
+        <add name="signals" connectionString="Data Source=(LocalDB)\MSSQLLocalDB;Database=Signals" />
     </connectionStrings>
     <startup>
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>

--- a/Signals/DatabaseMaintenanceTool/App.config
+++ b/Signals/DatabaseMaintenanceTool/App.config
@@ -1,9 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
-        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
-            <section name="DatabaseMaintenanceTool.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
-        </sectionGroup>
     </configSections>
     <connectionStrings>
         <add name="master" connectionString="Data Source=(LocalDB)\MSSQLLocalDB" />
@@ -12,11 +9,4 @@
     <startup>
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
-    <userSettings>
-        <DatabaseMaintenanceTool.Properties.Settings>
-            <setting name="RelativeDataDirectory" serializeAs="String">
-                <value>..\..\..\Hosting\bin\Debug</value>
-            </setting>
-        </DatabaseMaintenanceTool.Properties.Settings>
-    </userSettings>
 </configuration>

--- a/Signals/DatabaseMaintenanceTool/Program.cs
+++ b/Signals/DatabaseMaintenanceTool/Program.cs
@@ -6,8 +6,6 @@ namespace DatabaseMaintenanceTool
 {
     public class Program
     {
-        private const string DataDirectoryDataKey = "DataDirectory";
-
         public static void Main(string[] args)
         {
             if (args.Length == 0)
@@ -20,8 +18,6 @@ namespace DatabaseMaintenanceTool
             {
                 Console.WriteLine("Rebuilding database...");
 
-                SetupDataDirectory();
-
                 CreateDatabaseIfNotExists();
 
                 DatabaseMaintenance.DatabaseMaintenance dm = new DatabaseMaintenance.DatabaseMaintenance(new DataAccess.UnitOfWorkProvider());
@@ -32,23 +28,15 @@ namespace DatabaseMaintenanceTool
             }
         }
 
-        private static void SetupDataDirectory()
-        {
-            var relativeDataDirectory = Properties.Settings.Default["RelativeDataDirectory"] as string;
-            var absoluteDataDirectory = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, relativeDataDirectory));
-            AppDomain.CurrentDomain.SetData(DataDirectoryDataKey, absoluteDataDirectory);
-        }
-
         private static void CreateDatabaseIfNotExists()
         {
             string databaseName = "Signals";
-            string fileName = Path.Combine(AppDomain.CurrentDomain.GetData(DataDirectoryDataKey).ToString(), databaseName + ".mdf");
-
             string connectionString = ConfigurationManager.ConnectionStrings["master"].ConnectionString;
 
             using (var connection = new System.Data.SqlClient.SqlConnection(connectionString))
             {
                 connection.Open();
+
                 using (var command = connection.CreateCommand())
                 {
                     command.CommandText
@@ -56,7 +44,7 @@ namespace DatabaseMaintenanceTool
                     command.ExecuteNonQuery();
 
                     command.CommandText
-                        = string.Format("CREATE DATABASE {0} ON PRIMARY (NAME={0}, FILENAME='{1}')", databaseName, fileName);
+                        = string.Format("CREATE DATABASE {0}", databaseName);
                     command.ExecuteNonQuery();
                 }
             }

--- a/Signals/DatabaseMaintenanceTool/Program.cs
+++ b/Signals/DatabaseMaintenanceTool/Program.cs
@@ -44,7 +44,7 @@ namespace DatabaseMaintenanceTool
             string databaseName = "Signals";
             string fileName = Path.Combine(AppDomain.CurrentDomain.GetData(DataDirectoryDataKey).ToString(), databaseName + ".mdf");
 
-            string connectionString = ConfigurationManager.ConnectionStrings["signals"].ConnectionString;
+            string connectionString = ConfigurationManager.ConnectionStrings["master"].ConnectionString;
 
             using (var connection = new System.Data.SqlClient.SqlConnection(connectionString))
             {

--- a/Signals/DatabaseMaintenanceTool/Program.cs
+++ b/Signals/DatabaseMaintenanceTool/Program.cs
@@ -46,22 +46,18 @@ namespace DatabaseMaintenanceTool
 
             string connectionString = ConfigurationManager.ConnectionStrings["signals"].ConnectionString;
 
-            if (!File.Exists(fileName))
+            using (var connection = new System.Data.SqlClient.SqlConnection(connectionString))
             {
-                using (var connection = new System.Data.SqlClient.SqlConnection(connectionString))
+                connection.Open();
+                using (var command = connection.CreateCommand())
                 {
-                    connection.Open();
-                    using (var command = connection.CreateCommand())
-                    {
-                        command.CommandText
-                            = string.Format("CREATE DATABASE {0} ON PRIMARY (NAME={0}, FILENAME='{1}')", databaseName, fileName);
-                        command.ExecuteNonQuery();
+                    command.CommandText
+                        = string.Format("IF EXISTS (SELECT name FROM master.dbo.sysdatabases WHERE name = '{0}') DROP DATABASE {0}", databaseName);
+                    command.ExecuteNonQuery();
 
-                        command.CommandText
-                            = string.Format("EXEC sp_detach_db '{0}', 'true'", databaseName);
-
-                        command.ExecuteNonQuery();
-                    }
+                    command.CommandText
+                        = string.Format("CREATE DATABASE {0} ON PRIMARY (NAME={0}, FILENAME='{1}')", databaseName, fileName);
+                    command.ExecuteNonQuery();
                 }
             }
         }

--- a/Signals/DatabaseMaintenanceTool/Properties/Settings.Designer.cs
+++ b/Signals/DatabaseMaintenanceTool/Properties/Settings.Designer.cs
@@ -22,17 +22,5 @@ namespace DatabaseMaintenanceTool.Properties {
                 return defaultInstance;
             }
         }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("..\\..\\..\\Hosting\\bin\\Debug")]
-        public string RelativeDataDirectory {
-            get {
-                return ((string)(this["RelativeDataDirectory"]));
-            }
-            set {
-                this["RelativeDataDirectory"] = value;
-            }
-        }
     }
 }

--- a/Signals/DatabaseMaintenanceTool/Properties/Settings.settings
+++ b/Signals/DatabaseMaintenanceTool/Properties/Settings.settings
@@ -1,9 +1,5 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="DatabaseMaintenanceTool.Properties" GeneratedClassName="Settings">
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)">
   <Profiles />
-  <Settings>
-    <Setting Name="RelativeDataDirectory" Type="System.String" Scope="User">
-      <Value Profile="(Default)">..\..\..\Hosting\bin\Debug</Value>
-    </Setting>
-  </Settings>
+  <Settings />
 </SettingsFile>

--- a/Signals/Hosting/App.config
+++ b/Signals/Hosting/App.config
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <configSections>
-    </configSections>
-    <connectionStrings>
-        <add name="signals" connectionString="Data Source=(LocalDB)\MSSQLLocalDB" />
-    </connectionStrings>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
-    </startup>
+  <configSections>
+  </configSections>
+  <connectionStrings>
+    <add name="signals" connectionString="Data Source=(LocalDB)\MSSQLLocalDB;Database=Signals" />
+  </connectionStrings>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+  </startup>
 </configuration>


### PR DESCRIPTION
dbname is required in connection string (otherwise tables are created in master)
second connection string is needed for "master" connection (or maybe not, but it is more clean to have different connection, with possible different credentials etc. for db maintenance and filling)
