### PR TITLE
Changed prefix matching for signal paths: using string.StartsWith cau…

### DIFF
--- a/Signals/DataAccess/Repositories/SignalsRepository.cs
+++ b/Signals/DataAccess/Repositories/SignalsRepository.cs
@@ -57,7 +57,7 @@ namespace DataAccess.Repositories
             return Session
                 .QueryOver<Signal>()
                 .List<Signal>()
-                .Where(s => s.Path.ToString().StartsWith(path.ToString()))
+                .Where(s => s.Path.Components.Take(path.Length).SequenceEqual(path.Components))
                 .ToArray();
         }
 

--- a/SignalsIntegrationTests/SignalsIntegrationTests/PathStructureTests.cs
+++ b/SignalsIntegrationTests/SignalsIntegrationTests/PathStructureTests.cs
@@ -82,7 +82,7 @@ namespace SignalsIntegrationTests
         [TestMethod]
         public void GivenRootPath_WhenOnePathLevelPresentAndTwoSignalsOnThatLevel_ReturnsOneCommonSubpath()
         {
-            var topLevelDirectory = Path.Root + "topLevel";
+            var topLevelDirectory = Path.Root + "topLevelWithTwoSignals";
             var directory = topLevelDirectory + "twoSignals";
             var firstTopLevelSignalPath = directory + "topLevelSignal1";
             var secondTopLevelSignalPath = directory + "topLevelSignal2";
@@ -93,6 +93,22 @@ namespace SignalsIntegrationTests
             var result = GetPathEntry(topLevelDirectory);
 
             CollectionAssert.AreEquivalent(new[] { directory }, result.SubPaths.ToArray());
+        }
+
+        [TestMethod]
+        public void GivenPathsWithCommonPrefixInName_WhenRead_TreatsThemAsDifferent()
+        {
+            var topLevelDirectory = Path.Root + "topLevelWithCommonPrefix";
+            var directory1 = topLevelDirectory + "commonPrefix";
+            var directory2 = topLevelDirectory + "commonPrefixOther";
+
+            var expectedSignalPath = directory1 + "signal1";
+            AddNewIntegerSignal(path: expectedSignalPath);
+            AddNewIntegerSignal(path: directory2 + "signal2");
+
+            var result = GetPathEntry(directory1);
+
+            CollectionAssert.AreEquivalent(new[] { expectedSignalPath }, result.Signals.Select(s => s.Path).ToArray());
         }
     }
 }


### PR DESCRIPTION
…sed returning 'path_x/signal' when asking for signals from 'path/'. Comparing sequences of path components fixes the problem - 'path_x' != 'path'
