### PR TITLE
Proposals of solutions for problems with first implementation of firs…

### DIFF
--- a/Signals/Domain/Domain.csproj
+++ b/Signals/Domain/Domain.csproj
@@ -61,6 +61,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Exceptions\IncompatibleSignalDataType.cs" />
     <Compile Include="Exceptions\IdNotNullException.cs" />
     <Compile Include="Infrastructure\IInjectionMembersFactory.cs" />
     <Compile Include="Infrastructure\NHibernateIgnoreAttribute.cs" />

--- a/Signals/Domain/Exceptions/IncompatibleSignalDataType.cs
+++ b/Signals/Domain/Exceptions/IncompatibleSignalDataType.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Domain.Exceptions
+{
+    public class IncompatibleSignalDataType : Exception
+    {
+        public IncompatibleSignalDataType()
+            : base("Cannot set a missing value policy for a signal with incompatible data type")
+        {
+        }
+    }
+}

--- a/Signals/Domain/MissingValuePolicy/MissingValuePolicy.cs
+++ b/Signals/Domain/MissingValuePolicy/MissingValuePolicy.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 using Domain.Infrastructure; // TODO ugly dependency, change iface to DateTime
 
@@ -20,18 +21,30 @@ namespace Domain.MissingValuePolicy
 
         [NHibernateIgnore]
         public abstract Type NativeDataType { get; }
-    }
-
-    public abstract class MissingValuePolicy<T> : MissingValuePolicyBase
-    {
-        [NHibernateIgnore]
-        public override Type NativeDataType { get { return typeof(T); } }
 
         [NHibernateIgnore]
         public virtual int OlderDataSampleCountNeeded { get { return 0; } }
 
         [NHibernateIgnore]
         public virtual int NewerDataSampleCountNeeded { get { return 0; } }
+
+        [NHibernateIgnore]
+        public virtual IEnumerable<Type> CompatibleNativeTypes
+        {
+            get
+            {
+                return Enum
+                    .GetValues(typeof(DataType))
+                    .Cast<DataType>()
+                    .Select(dt => dt.GetNativeType());
+            }
+        }
+    }
+
+    public abstract class MissingValuePolicy<T> : MissingValuePolicyBase
+    {
+        [NHibernateIgnore]
+        public override Type NativeDataType { get { return typeof(T); } }
 
         public abstract IEnumerable<Datum<T>> FillMissingData(
             TimeEnumerator timeEnumerator,

--- a/Signals/Domain/Services/ISignalsDomainService.cs
+++ b/Signals/Domain/Services/ISignalsDomainService.cs
@@ -19,6 +19,6 @@ namespace Domain.Services
 
         MissingValuePolicy.MissingValuePolicyBase GetMissingValuePolicy(Signal signal);
 
-        void SetMissingValuePolicyConfig(Signal signal, MissingValuePolicy.MissingValuePolicyBase missingValuePolicy);
+        void SetMissingValuePolicy(Signal signal, MissingValuePolicy.MissingValuePolicyBase missingValuePolicy);
     }
 }

--- a/Signals/Domain/Services/Implementation/SignalsDomainService.cs
+++ b/Signals/Domain/Services/Implementation/SignalsDomainService.cs
@@ -127,8 +127,13 @@ namespace Domain.Services.Implementation
                 as MissingValuePolicy.MissingValuePolicyBase;
         }
 
-        public void SetMissingValuePolicyConfig(Signal signal, MissingValuePolicy.MissingValuePolicyBase missingValuePolicy)
+        public void SetMissingValuePolicy(Signal signal, MissingValuePolicy.MissingValuePolicyBase missingValuePolicy)
         {
+            if (!missingValuePolicy.CompatibleNativeTypes.Contains(signal.DataType.GetNativeType()))
+            {
+                throw new IncompatibleSignalDataType();
+            }
+
             this.missingValuePolicyRepository.Set(signal, missingValuePolicy);
         }
     }

--- a/Signals/WebService/SignalsWebService.cs
+++ b/Signals/WebService/SignalsWebService.cs
@@ -122,7 +122,7 @@ namespace WebService
         {
             var mvp = missingValuePolicy.ToDomain<Domain.MissingValuePolicy.MissingValuePolicyBase>();
 
-            this.signalsDomainService.SetMissingValuePolicyConfig(
+            this.signalsDomainService.SetMissingValuePolicy(
                 this.signalsDomainService.Get(signalId),
                 mvp);
         }

--- a/SignalsIntegrationTests/SignalsIntegrationTests/BasicSignalTests.cs
+++ b/SignalsIntegrationTests/SignalsIntegrationTests/BasicSignalTests.cs
@@ -30,6 +30,16 @@ namespace SignalsIntegrationTests
         }
 
         [TestMethod]
+        public void RequestForSettingFirstOrderMissingValuePolicyForStringThrows()
+        {
+            var signalId = AddNewStringSignal().Id.Value;
+
+            Assertions.AssertThrows(() => client.SetMissingValuePolicy(
+                signalId,
+                (new Domain.MissingValuePolicy.FirstOrderMissingValuePolicy<string>()).ToDto<Dto.MissingValuePolicy.MissingValuePolicy>()));
+        }
+
+        [TestMethod]
         public void AddingSignalSetsItsId()
         {
             var signal = new Signal()

--- a/SignalsIntegrationTests/SignalsIntegrationTests/BasicSignalTests.cs
+++ b/SignalsIntegrationTests/SignalsIntegrationTests/BasicSignalTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ServiceModel;
 using Domain;
 using Dto.Conversions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -30,13 +31,16 @@ namespace SignalsIntegrationTests
         }
 
         [TestMethod]
+        [ExpectedException(typeof(FaultException), AllowDerivedTypes = true)]
         public void RequestForSettingFirstOrderMissingValuePolicyForStringThrows()
         {
             var signalId = AddNewStringSignal().Id.Value;
 
-            Assertions.AssertThrows(() => client.SetMissingValuePolicy(
-                signalId,
-                (new Domain.MissingValuePolicy.FirstOrderMissingValuePolicy<string>()).ToDto<Dto.MissingValuePolicy.MissingValuePolicy>()));
+            var firstOrderMissingValuePolicy
+                 = (new Domain.MissingValuePolicy.FirstOrderMissingValuePolicy<string>())
+                 .ToDto<Dto.MissingValuePolicy.MissingValuePolicy>();
+
+            client.SetMissingValuePolicy(signalId, firstOrderMissingValuePolicy);
         }
 
         [TestMethod]

--- a/SignalsIntegrationTests/SignalsIntegrationTests/Infrastructure/Assertions.cs
+++ b/SignalsIntegrationTests/SignalsIntegrationTests/Infrastructure/Assertions.cs
@@ -19,18 +19,6 @@ namespace SignalsIntegrationTests.Infrastructure
             }
         }
 
-        public static void AssertThrows(Action f)
-        {
-            try
-            {
-                f();
-                throw new AssertFailedException();
-            }
-            catch (FaultException)
-            {
-            }
-        }
-
         public static void AssertEqual<T>(IEnumerable<Domain.Datum<T>> expected, IEnumerable<Domain.Datum<T>> actual)
         {
             CollectionAssert.AreEqual(

--- a/SignalsIntegrationTests/SignalsIntegrationTests/Infrastructure/Assertions.cs
+++ b/SignalsIntegrationTests/SignalsIntegrationTests/Infrastructure/Assertions.cs
@@ -19,6 +19,18 @@ namespace SignalsIntegrationTests.Infrastructure
             }
         }
 
+        public static void AssertThrows(Action f)
+        {
+            try
+            {
+                f();
+                throw new AssertFailedException();
+            }
+            catch (FaultException)
+            {
+            }
+        }
+
         public static void AssertEqual<T>(IEnumerable<Domain.Datum<T>> expected, IEnumerable<Domain.Datum<T>> actual)
         {
             CollectionAssert.AreEqual(

--- a/SignalsIntegrationTests/SignalsIntegrationTests/Infrastructure/TestsBase.cs
+++ b/SignalsIntegrationTests/SignalsIntegrationTests/Infrastructure/TestsBase.cs
@@ -57,7 +57,7 @@ namespace SignalsIntegrationTests.Infrastructure
         {
             var signal = new Signal()
             {
-                Path = Path.FromString("/new/string_signal"),
+                Path = SignalPathGenerator.Generate(),
                 Granularity = Granularity.Day,
                 DataType = DataType.String
             };

--- a/SignalsIntegrationTests/SignalsIntegrationTests/Infrastructure/TestsBase.cs
+++ b/SignalsIntegrationTests/SignalsIntegrationTests/Infrastructure/TestsBase.cs
@@ -52,5 +52,17 @@ namespace SignalsIntegrationTests.Infrastructure
 
             return client.Add(signal.ToDto<Dto.Signal>());
         }
+
+        protected Dto.Signal AddNewStringSignal()
+        {
+            var signal = new Signal()
+            {
+                Path = Path.FromString("/new/string_signal"),
+                Granularity = Granularity.Day,
+                DataType = DataType.String
+            };
+
+            return client.Add(signal.ToDto<Dto.Signal>());
+        }
     }
 }


### PR DESCRIPTION
…t order missing value policy. 1) Semantical order of values of Quality enum is determined by their syntactical order 2) FirstOrderMissingValuePolicy cannot be applied to a signal of type string
