### PR TITLE
Assertion.AssertReturnsNullOrThrows removed

### DIFF
--- a/Signals/Domain.Tests/SignalsDomainServiceTests.cs
+++ b/Signals/Domain.Tests/SignalsDomainServiceTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Domain.Repositories;
+﻿using Domain.Repositories;
 using Domain.Services;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Rhino.Mocks;
@@ -12,12 +11,13 @@ namespace Domain.Tests
         private ISignalsDomainService signalsDomainService;
 
         [TestMethod]
-        [ExpectedException(typeof(KeyNotFoundException))]
         public void GivenNoSignals_WhenGettingSignal_ThrowsKeyNotFoundException()
         {
             GivenNoSignals();
 
-            WhenGettingSignalByPath(Path.FromString(string.Empty));
+            var result = WhenGettingSignalByPath(Path.FromString(string.Empty));
+
+            Assert.IsNull(result);
         }
 
         [TestMethod]

--- a/Signals/Domain/Services/Implementation/SignalsDomainService.cs
+++ b/Signals/Domain/Services/Implementation/SignalsDomainService.cs
@@ -27,26 +27,12 @@ namespace Domain.Services.Implementation
 
         public Signal Get(Path path)
         {
-            var result = this.signalsRepository.Get(path);
-
-            if (result == null)
-            {
-                throw new KeyNotFoundException();
-            }
-
-            return result;
+            return this.signalsRepository.Get(path);
         }
 
         public Signal Get(int signalId)
         {
-            var result = this.signalsRepository.Get(signalId);
-
-            if (result == null)
-            {
-                throw new KeyNotFoundException();
-            }
-
-            return result;
+            return this.signalsRepository.Get(signalId);
         }
  
         public Signal Add(Signal signal)

--- a/Signals/WebService/SignalsWebService.cs
+++ b/Signals/WebService/SignalsWebService.cs
@@ -29,12 +29,12 @@ namespace WebService
         {
             var path = pathDto.ToDomain<Domain.Path>();
 
-            return this.signalsDomainService.Get(path).ToDto<Signal>();
+            return this.signalsDomainService.Get(path)?.ToDto<Signal>();
         }
 
         public Signal GetById(int signalId)
         {
-            return this.signalsDomainService.Get(signalId).ToDto<Signal>();
+            return this.signalsDomainService.Get(signalId)?.ToDto<Signal>();
         }
 
         public Signal Add(Signal signalDto)
@@ -68,6 +68,8 @@ namespace WebService
                 .Invoke(this.signalsDomainService, new object[] { signal, fromIncludedUtc, toExcludedUtc })
                 as IEnumerable;
 
+            if (result == null)
+                return null;
             return result
                 .Cast<object>()
                 .Select(d => d.ToDto<Datum>())

--- a/Signals/WebService/SignalsWebService.cs
+++ b/Signals/WebService/SignalsWebService.cs
@@ -70,6 +70,7 @@ namespace WebService
 
             if (result == null)
                 return null;
+
             return result
                 .Cast<object>()
                 .Select(d => d.ToDto<Datum>())
@@ -121,6 +122,11 @@ namespace WebService
         {
             var signal = this.signalsDomainService.Get(signalId);
 
+            if (signal == null)
+            {
+                throw new KeyNotFoundException();
+            }
+
             return this.signalsDomainService.GetMissingValuePolicy(signal)?
                 .ToDto<MissingValuePolicy>();
         }
@@ -129,8 +135,15 @@ namespace WebService
         {
             var mvp = missingValuePolicy.ToDomain<Domain.MissingValuePolicy.MissingValuePolicyBase>();
 
+            var signal = this.signalsDomainService.Get(signalId);
+
+            if (signal == null)
+            {
+                throw new KeyNotFoundException();
+            }
+
             this.signalsDomainService.SetMissingValuePolicy(
-                this.signalsDomainService.Get(signalId),
+                signal,
                 mvp);
         }
     }

--- a/SignalsIntegrationTests/SignalsIntegrationTests/BasicSignalTests.cs
+++ b/SignalsIntegrationTests/SignalsIntegrationTests/BasicSignalTests.cs
@@ -22,11 +22,11 @@ namespace SignalsIntegrationTests
         }
 
         [TestMethod]
-        public void RequestForNonExistingSignalThrowsOrReturnsNull()
+        public void RequestForNonExistingSignalReturnsNull()
         {
             var path = Path.FromString("/non/existent/path");
 
-            Assertions.AssertReturnsNullOrThrows(() => client.Get(path.ToDto<Dto.Path>()));
+            Assert.IsNull(client.Get(path.ToDto<Dto.Path>()));
         }
 
         [TestMethod]
@@ -106,7 +106,7 @@ namespace SignalsIntegrationTests
         }
 
         [TestMethod]
-        public void TryingToAddSignalWithExistingPathThrowsOrReturnsNull()
+        public void TryingToAddSignalWithExistingPathThrows()
         {
             var signal = new Signal()
             {
@@ -117,11 +117,11 @@ namespace SignalsIntegrationTests
 
             client.Add(signal.ToDto<Dto.Signal>());
 
-            Assertions.AssertReturnsNullOrThrows(() => client.Add(signal.ToDto<Dto.Signal>()));
+            Assertions.AssertThrows(() => client.Add(signal.ToDto<Dto.Signal>()));
         }
 
         [TestMethod]
-        public void TryingToAddSignalWithNotNullIdThrowsOrReturnsNull()
+        public void TryingToAddSignalWithNotNullIdThrows()
         {
             var signal = new Signal()
             {
@@ -131,7 +131,7 @@ namespace SignalsIntegrationTests
                 Id = 42
             };
 
-            Assertions.AssertReturnsNullOrThrows(() => client.Add(signal.ToDto<Dto.Signal>()));
+            Assertions.AssertThrows(() => client.Add(signal.ToDto<Dto.Signal>()));
         }
 
         [TestMethod]
@@ -185,7 +185,7 @@ namespace SignalsIntegrationTests
 
             client.Delete(signalId);
 
-            Assertions.AssertThrows(() => client.GetById(signalId));
+            Assert.IsNull(client.GetById(signalId));
         }
 
         [TestMethod]

--- a/SignalsIntegrationTests/SignalsIntegrationTests/BasicSignalTests.cs
+++ b/SignalsIntegrationTests/SignalsIntegrationTests/BasicSignalTests.cs
@@ -145,6 +145,21 @@ namespace SignalsIntegrationTests
         }
 
         [TestMethod]
+        public void WhenGettingMissingValuePolicyForNonExistentSignal_Throws()
+        {
+            Assertions.AssertThrows(() => client.GetMissingValuePolicy(0));
+        }
+
+        [TestMethod]
+        public void WhenSettingsMissingValuePolicyForNonExistentSignal_Throws()
+        {
+            var mvp = new Domain.MissingValuePolicy.NoneQualityMissingValuePolicy<int>()
+                .ToDto<Dto.MissingValuePolicy.MissingValuePolicy>();
+
+            Assertions.AssertThrows(() => client.SetMissingValuePolicy(0, mvp));
+        }
+
+        [TestMethod]
         public void MissingValuePolicyCanBeSetForSignal()
         {
             var signal1Id = AddNewIntegerSignal().Id.Value;

--- a/SignalsIntegrationTests/SignalsIntegrationTests/Infrastructure/Assertions.cs
+++ b/SignalsIntegrationTests/SignalsIntegrationTests/Infrastructure/Assertions.cs
@@ -8,18 +8,6 @@ namespace SignalsIntegrationTests.Infrastructure
 {
     public static class Assertions
     {
-        public static void AssertReturnsNullOrThrows<T>(Func<T> f) where T : class
-        {
-            try
-            {
-                Assert.IsNull(f());
-            }
-            catch (FaultException e)
-            {
-                AssertNotDefaultException(e);
-            }
-        }
-
         public static void AssertThrows(Action f)
         {
             try

--- a/SignalsIntegrationTests/SignalsIntegrationTests/SignalDataTests.cs
+++ b/SignalsIntegrationTests/SignalsIntegrationTests/SignalDataTests.cs
@@ -124,11 +124,11 @@ namespace SignalsIntegrationTests
         }
 
         [TestMethod]
-        public void GetDataUsingIncompleteSignalsThrowsOrReturnsNull()
+        public void GetDataUsingIncompleteSignalsThrows()
         {
             int dummySignalId = 0;
 
-            Assertions.AssertReturnsNullOrThrows(() => client.GetData(dummySignalId, new DateTime(2016, 12, 10), new DateTime(2016, 12, 14)));
+            Assertions.AssertThrows(() => client.GetData(dummySignalId, new DateTime(2016, 12, 10), new DateTime(2016, 12, 14)));
         }
 
         [TestMethod]

--- a/SignalsIntegrationTests/SignalsIntegrationTests/SignalDataTests.cs
+++ b/SignalsIntegrationTests/SignalsIntegrationTests/SignalDataTests.cs
@@ -124,7 +124,7 @@ namespace SignalsIntegrationTests
         }
 
         [TestMethod]
-        public void GetDataUsingIncompleteSignalsThrows()
+        public void GetDataUsingNonExistentSignalsThrows()
         {
             int dummySignalId = 0;
 


### PR DESCRIPTION
now explicit AssertThrows or IsNull are used in specific tests

Fixes #33
